### PR TITLE
add support django 2 and django-cms-3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+  ** unreleased
+  * Replace 'mark_safe' modules path by 'from django.utils.safestring' for compatibilty Django 2.0
+  
 -1.1
   * Do no render menu item pointing onto current page in bold.
   * Add templatetag `menu_icon`, which in combination with **djangocms-cascade** version 0.19+, renders an icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
   ** unreleased
-  * Replace 'mark_safe' modules path by 'from django.utils.safestring' for compatibilty Django 2.0
+  * Replace 'mark_safe' modules path by 'from django.utils.safestring' for compatibilty Django 2.0.
   
 -1.1
   * Do no render menu item pointing onto current page in bold.

--- a/cms_bootstrap/templatetags/bootstrap_tags.py
+++ b/cms_bootstrap/templatetags/bootstrap_tags.py
@@ -3,7 +3,11 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django import template
-from django.utils.text import mark_safe
+from django import VERSION as DJANGO_VERSION
+if DJANGO_VERSION < (2, 0):
+   from django.utils.text import mark_safe
+else:
+   from django.utils.safestring import mark_safe
 from cms.models.pagemodel import Page
 from menus.menu_pool import menu_pool
 from classytags.arguments import IntegerArgument, StringArgument, Argument, Flag

--- a/cms_bootstrap/templatetags/bootstrap_tags.py
+++ b/cms_bootstrap/templatetags/bootstrap_tags.py
@@ -4,10 +4,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django import template
 from django import VERSION as DJANGO_VERSION
-if DJANGO_VERSION < (1, 11):
-   from django.utils.text import mark_safe
-else:
-   from django.utils.safestring import mark_safe
+from django.utils.safestring import mark_safe
 from cms.models.pagemodel import Page
 from menus.menu_pool import menu_pool
 from classytags.arguments import IntegerArgument, StringArgument, Argument, Flag

--- a/cms_bootstrap/templatetags/bootstrap_tags.py
+++ b/cms_bootstrap/templatetags/bootstrap_tags.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django import template
 from django import VERSION as DJANGO_VERSION
-if DJANGO_VERSION < (2, 0):
+if DJANGO_VERSION < (1, 11):
    from django.utils.text import mark_safe
 else:
    from django.utils.safestring import mark_safe

--- a/cms_bootstrap/templatetags/bootstrap_tags.py
+++ b/cms_bootstrap/templatetags/bootstrap_tags.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django import template
-from django import VERSION as DJANGO_VERSION
 from django.utils.safestring import mark_safe
 from cms.models.pagemodel import Page
 from menus.menu_pool import menu_pool

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ CLASSIFIERS = [
     'Framework :: Django :: 1.10',
     'Framework :: Django :: 1.11',
     'Framework :: Django :: 2.1',
+    'Framework :: Django :: 2.1',
+    'Framework :: Django :: 2.2',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
     'Framework :: Django :: 1.10',
     'Framework :: Django :: 1.11',
+    'Framework :: Django :: 2.1',
 ]
 
 setup(
@@ -36,7 +37,7 @@ setup(
     url='https://github.com/jrief/djangocms-bootstrap',
     packages=find_packages(),
     install_requires=[
-        'django-cms>3.4,<3.6',
+        'django-cms>3.4,<3.7',
     ],
     license='MIT',
     platforms=['OS Independent'],

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
     'Framework :: Django :: 1.10',
     'Framework :: Django :: 1.11',
+    'Framework :: Django :: 2.0',
     'Framework :: Django :: 2.1',
     'Framework :: Django :: 2.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ CLASSIFIERS = [
     'Framework :: Django :: 1.10',
     'Framework :: Django :: 1.11',
     'Framework :: Django :: 2.1',
-    'Framework :: Django :: 2.1',
     'Framework :: Django :: 2.2',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ CLASSIFIERS = [
     'Framework :: Django :: 1.11',
     'Framework :: Django :: 2.0',
     'Framework :: Django :: 2.1',
-    'Framework :: Django :: 2.2',
 ]
 
 setup(


### PR DESCRIPTION
In django 2, `mark_safe` import change and djangocms-bootstrap need to accept django-cms-3.6.
Sorry for commit message, maybe i can rename it.